### PR TITLE
Add pre-commit CI job to run external hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,27 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  pre-commit:
+    name: Pre-commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+
   build:
     name: Build (${{ matrix.os }})
+    needs: [pre-commit]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Adds a pre-commit job to the CI workflow that runs external hooks from `.pre-commit-config.yaml`
- The pre-commit job runs before the build job to catch issues early

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline with automated code quality checks that run before each build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->