### PR TITLE
fix: publish to npm via trusted publishing only

### DIFF
--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -86,7 +86,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Patch version from tag
         if: startsWith(github.ref, 'refs/tags/v')
@@ -130,23 +129,12 @@ jobs:
       - name: List npm package contents
         run: find npm -maxdepth 2 -type f | sort
 
-      - name: Configure npm publish auth
-        shell: bash
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -n "${NPM_TOKEN:-}" ]; then
-            printf '//registry.npmjs.org/:_authToken=%s\n' "${NPM_TOKEN}" > "${HOME}/.npmrc"
-            echo "Configured npm token auth."
-          else
-            rm -f "${HOME}/.npmrc"
-            echo "No NPM_TOKEN provided; using trusted publishing (OIDC)."
-          fi
-
       - name: Publish platform packages to npm
         run: |
           set -euo pipefail
+          rm -f "${HOME}/.npmrc"
+          unset NODE_AUTH_TOKEN
+          echo "Using trusted publishing (OIDC)."
           mapfile -t package_dirs < <(find npm -mindepth 1 -maxdepth 1 -type d | sort)
           if [ "${#package_dirs[@]}" -eq 0 ]; then
             echo "No generated platform package directories found under npm/"
@@ -158,7 +146,10 @@ jobs:
           done
 
       - name: Publish root package to npm
-        run: npm publish --provenance --access public
+        run: |
+          rm -f "${HOME}/.npmrc"
+          unset NODE_AUTH_TOKEN
+          npm publish --provenance --access public
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
- remove token-based npm auth path from `npm.yaml`
- enforce trusted publishing flow for npm releases:
  - no `registry-url` injection in setup-node
  - clear `~/.npmrc` and `NODE_AUTH_TOKEN` before platform/root publish
- keeps provenance-enabled publish commands and path fix (`./npm/<target>`)

## Why
`v0.1.17` npm publish failed because CI token auth is present but revoked/expired. Trusted publishing via OIDC avoids this dependency.

## Validation
- npm run test:node
